### PR TITLE
minor bugfix, improve platform support

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,6 +3,9 @@
 ## Generic variables
 ###########################
 
+# The release (https://github.com/matrix-org/synapse/releases) of Synapse you will use
+matrix_version: master
+
 # The matrix domain you will use
 #matrix_domain: "mydomain"
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -14,9 +14,12 @@ galaxy_info:
   - name: Fedora
     versions:
     - all
+  - name: Debian
+    versions:
+    - jessie
   - name: Ubuntu
     versions:
-    - all
+    - xenial
   categories:
   - networking
   - system

--- a/molecule.yml
+++ b/molecule.yml
@@ -1,0 +1,25 @@
+---
+ansible:
+  verbose: v
+driver:
+  name: vagrant
+vagrant:
+  platforms:
+    - name: debian8
+      box: debian/jessie64
+    - name: centos7
+      box: centos/7
+    - name: xenial64
+      box: ubuntu/xenial64
+  providers:
+    - name: virtualbox
+      type: virtualbox
+      options:
+        memory: 512
+        cpus: 1
+  instances:
+    - name: ansible-matrix-synapse
+      ansible_groups:
+        - group1
+verifier:
+  name: testinfra

--- a/playbook.yml
+++ b/playbook.yml
@@ -1,0 +1,6 @@
+---
+- hosts: all
+  vars:
+    matrix_domain: "{{ ansible_fqdn }}"
+  roles:
+    - role: ansible-matrix-synapse

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,35 +1,70 @@
 ---
+- name: Common dependencies for all platforms
+  package:
+    state: installed
+    name: "{{item}}"
+  with_items:
+  - openssl
+  - python-virtualenv
+  - python-setuptools
+
+- name: Dependencies are installed on EL derivatives
+  yum:
+    state: installed
+    name: "{{item}}"
+  with_items:
+  - "@Development tools"
+  - openssl-devel
+  - libffi-devel
+  - libjpeg-devel
+  - postgresql-devel
+  when: ansible_pkg_mgr == 'yum'
+
 - name: Dependencies are installed on Fedora
   dnf:
     state: installed
     name: "{{item}}"
   with_items:
   - "@c-development"
-  - openssl
   - openssl-devel
   - libffi-devel
   - python-setuptools
-  - python-virtualenv
   - libjpeg-turbo-devel
   - libjpeg-turbo
   - postgresql-devel
-  when: ansible_distribution == 'Fedora' 
+  when: ansible_distribution == 'Fedora'
+
+- name: Common dependencies are installed on Debian derivatives
+  apt:
+    state: installed
+    name: "{{item}}"
+  with_items:
+  - build-essential
+  - libssl-dev
+  - libffi-dev
+  - python-setuptools
+  - python-virtualenv
+  - libpq-dev
+  - libpython2.7-dev
+  - libxslt1-dev
+  when: ansible_os_family == 'Debian'
 
 - name: Dependencies are installed on Debian
   apt:
     state: installed
     name: "{{item}}"
   with_items:
-  - openssl
-  - libffi-dev
-  - python-setuptools
-  - python-virtualenv
+  - libjpeg-dev
   - virtualenv
+  when: ansible_distribution == 'Debian'
+
+- name: Dependencies are installed on Ubuntu
+  apt:
+    state: installed
+    name: "{{item}}"
+  with_items:
   - libjpeg-turbo8-dev
-  - libjpeg-turbo8
-  - libpq-dev
-  - libpython2.7-dev
-  when: ansible_os_family == 'Debian' 
+  when: ansible_distribution == 'Ubuntu'
 
 - name: Synapse user exists
   user:
@@ -43,6 +78,7 @@
     name: "{{item}}"
     extra_args: --process-dependency-links
   with_items:
+    - pip
     - setuptools
     - psycopg2
   sudo_user: synapse

--- a/templates/homeserver.yaml.j2
+++ b/templates/homeserver.yaml.j2
@@ -170,7 +170,7 @@ max_image_pixels: "32M"
 # the resolution requested by the client. If true then whenever
 # a new resolution is requested by the client the server will
 # generate a new thumbnail. If false the server will pick a thumbnail
-# from a precalcualted list.
+# from a precalculated list.
 dynamic_thumbnails: false
 
 # List of thumbnail to precalculate when an image is uploaded.


### PR DESCRIPTION
- The 'matrix_version' variable appears to be required, so I added it to the defaults.
- I added support for Debian (current version: jessie/8) and made some fixes to the support for Ubuntu (esp. Xenial, 16.04 LTS) and EL(7) derivatives.
- I added basic support for testing this role with [Molecule](http://molecule.readthedocs.io/en/stable-1.17/)